### PR TITLE
Locale test

### DIFF
--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -42,7 +42,7 @@ class FormatTest extends TestCase
     public function testSvSeFormat()
     {
         $numerics = new Numerics();
-        $numerics->setLocale('sv_SE.utf8');
+        $numerics->setLocale('sv_SE.utf-8');
 
         $this->assertEquals('1 234,56', $numerics->format(1234.56, 2));
     }
@@ -53,7 +53,7 @@ class FormatTest extends TestCase
     public function testEnUsFormat()
     {
         $numerics = new Numerics();
-        $numerics->setLocale('en_US.utf8');
+        $numerics->setLocale('en_US.utf-8');
 
         $this->assertEquals('1,234.56', $numerics->format(1234.56, 2));
     }

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -158,7 +158,7 @@ class ParseTest extends TestCase
     public function testLocaleSvSe()
     {
         $numerics = new Numerics();
-        $numerics->setLocale('sv_SE.utf8');
+        $numerics->setLocale('sv_SE.utf-8');
 
         $this->assertSame(12345.0, $numerics->parse('12 345'));
         $this->assertSame(12.345, $numerics->parse('12.345'));
@@ -171,7 +171,7 @@ class ParseTest extends TestCase
     public function testLocaleEnUs()
     {
         $numerics = new Numerics();
-        $numerics->setLocale('en_US.utf8');
+        $numerics->setLocale('en_US.utf-8');
 
         $this->assertSame(12345.0, $numerics->parse('12 345'));
         $this->assertSame(12.345, $numerics->parse('12.345'));


### PR DESCRIPTION
It seems `utf8` isn't supported on some systems, but `utf-8` works on all I tried (including Travis).